### PR TITLE
Update link to Github repo

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -90,7 +90,7 @@
         </p>
         <p>
             The code for the encyclopedia project is open source and available on
-            <a rel="nofollow" href="https://github.com/MarginaliaSearch/MarginaliaEncyclopedia">github</a>.
+            <a rel="nofollow" href="https://github.com/MarginaliaSearch/encyclopedia.marginalia.nu">github</a>.
         </p>
         <p>
             The service itself runs off a Raspberry Pi, so depending on the amount of traffic it may sometimes


### PR DESCRIPTION
One-liner change: the link on the Encyclopedia's home page that points to its Github repo is currently pointing to "https://github.com/MarginaliaSearch/MarginaliaEncyclopedia" which leads to a 404. I've updated the link to use this repo's current URL.

<img width="546" alt="Screenshot 2023-08-30 at 10 44 58 PM" src="https://github.com/MarginaliaSearch/encyclopedia.marginalia.nu/assets/26191851/1b942dad-2601-4ee7-b433-648e22abd137">
